### PR TITLE
add os_cacert to keystone_user provider

### DIFF
--- a/keystone/lib/puppet/provider/keystone_user/openstack.rb
+++ b/keystone/lib/puppet/provider/keystone_user/openstack.rb
@@ -116,6 +116,7 @@ Puppet::Type.type(:keystone_user).provide(
       end
       credentials.password = resource[:password]
       credentials.user_id = id
+      credentials.cacert = '/etc/keystone/ssl/certs/ca.pem'
 
       # NOTE: The only reason we use username is so that the openstack provider
       # will know we are doing v3password auth - otherwise, it is not used.  The


### PR DESCRIPTION
Partial-Bug: #1689761

this change is needed to ensure certificate validations are ignored

PATCH2 :
removed --insecure for newton as it worked without it with newer version of
urllib3 and ssl-hostname-match packages