### PR TITLE
Cinder and Nova puppet third party hooks to configure rabbit params

### DIFF
--- a/cinder/manifests/init.pp
+++ b/cinder/manifests/init.pp
@@ -56,6 +56,20 @@
 #   (optional) Use HA queues in RabbitMQ (x-ha-policy: all).
 #   Defaults to $::os_service_default
 #
+# [*rabbit_retry_interval*]
+#   (Optional) How frequently to retry connecting with RabbitMQ.
+#   (integer value)
+#   Defaults to $::os_service_default
+#
+# [*rabbit_retry_backoff*]
+#   (Optional) How long to backoff for between retries when connecting
+#   to RabbitMQ. (integer value)
+#   Defaults to $::os_service_default
+#
+# [*rabbit_max_retries*]
+#   (Optional) Maximum number of RabbitMQ connection retries. (integer value)
+#   Defaults to $::os_service_default
+#
 # [*rabbit_heartbeat_timeout_threshold*]
 #   (optional) Number of seconds after which the RabbitMQ broker is considered
 #   down if the heartbeat keepalive fails.  Any value >0 enables heartbeats.
@@ -324,6 +338,9 @@ class cinder (
   $rabbit_ha_queues                   = $::os_service_default,
   $rabbit_heartbeat_timeout_threshold = $::os_service_default,
   $rabbit_heartbeat_rate              = $::os_service_default,
+  $rabbit_retry_interval              = $::os_service_default,
+  $rabbit_retry_backoff               = $::os_service_default,
+  $rabbit_max_retries                 = $::os_service_default,
   $rabbit_userid                      = $::os_service_default,
   $rabbit_password                    = $::os_service_default,
   $rabbit_use_ssl                     = $::os_service_default,
@@ -417,6 +434,9 @@ class cinder (
       rabbit_port                 => $rabbit_port,
       rabbit_hosts                => $rabbit_hosts,
       rabbit_ha_queues            => $rabbit_ha_queues,
+      rabbit_retry_interval       => $rabbit_retry_interval,
+      rabbit_retry_backoff        => $rabbit_retry_backoff,
+      rabbit_max_retries          => $rabbit_max_retries,
       heartbeat_timeout_threshold => $rabbit_heartbeat_timeout_threshold,
       heartbeat_rate              => $rabbit_heartbeat_rate,
       rabbit_use_ssl              => $rabbit_use_ssl,

--- a/nova/manifests/init.pp
+++ b/nova/manifests/init.pp
@@ -120,6 +120,20 @@
 #   the heartbeat will be checked every 30 seconds. (integer value)
 #   Defaults to $::os_service_default
 #
+# [*rabbit_retry_interval*]
+#   (Optional) How frequently to retry connecting with RabbitMQ.
+#   (integer value)
+#   Defaults to $::os_service_default
+#
+# [*rabbit_retry_backoff*]
+#   (Optional) How long to backoff for between retries when connecting
+#   to RabbitMQ. (integer value)
+#   Defaults to $::os_service_default
+#
+# [*rabbit_max_retries*]
+#   (Optional) Maximum number of RabbitMQ connection retries. (integer value)
+#   Defaults to $::os_service_default
+#
 # [*kombu_ssl_ca_certs*]
 #   (optional) SSL certification authority file (valid only if SSL enabled).
 #   (string value)
@@ -462,6 +476,9 @@ class nova(
   $rabbit_heartbeat_timeout_threshold     = $::os_service_default,
   $rabbit_heartbeat_rate                  = $::os_service_default,
   $rabbit_ha_queues                       = $::os_service_default,
+  $rabbit_retry_interval                  = $::os_service_default,
+  $rabbit_retry_backoff                   = $::os_service_default,
+  $rabbit_max_retries                     = $::os_service_default,
   $kombu_ssl_ca_certs                     = $::os_service_default,
   $kombu_ssl_certfile                     = $::os_service_default,
   $kombu_ssl_keyfile                      = $::os_service_default,
@@ -673,6 +690,9 @@ but should be one of: ssh-rsa, ssh-dsa, ssh-ecdsa.")
       rabbit_host                 => $rabbit_host,
       rabbit_port                 => $rabbit_port,
       rabbit_ha_queues            => $rabbit_ha_queues,
+      rabbit_retry_interval       => $rabbit_retry_interval,
+      rabbit_retry_backoff        => $rabbit_retry_backoff,
+      rabbit_max_retries          => $rabbit_max_retries,
     }
   } elsif $rpc_backend == 'amqp' {
     oslo::messaging::amqp { 'nova_config':


### PR DESCRIPTION
Partial-Bug: #1708251 - Add hooks to Cinder to be able to configure rabbit params

These rabbit params are available in pupet code for Newton only
In Mitaka we will continue to use cinder config

Change-Id: I4f07c1a2fc68fd8bb0a32c9081a82abd54794d3f