### PR TITLE
Novncproxy_base_url cannot be set independently [Mitaka]

### DIFF
--- a/nova/manifests/vncproxy.pp
+++ b/nova/manifests/vncproxy.pp
@@ -53,8 +53,6 @@ class nova::vncproxy(
     'DEFAULT/novncproxy_port': value => $port;
   }
 
-  include ::nova::vncproxy::common
-
   if ! defined(Package['python-numpy']) {
     package { 'python-numpy':
       ensure => present,


### PR DESCRIPTION
Partial-Bug: #1707985 - novncproxy_base_url is not allowed to be set directly

The puppet code forces us to set vnc/novncproxy_base_url as the listen IP and port of vncproxy service
In HA case, the port and host are different from URL host and port

Change-Id: I9d9196d668d0b560b313f42dfdc0b10719a042d6