### PR TITLE
Novncproxy_base_url cannot be set independently [Newton]

### DIFF
--- a/nova/manifests/vncproxy.pp
+++ b/nova/manifests/vncproxy.pp
@@ -53,8 +53,6 @@ class nova::vncproxy(
     'vnc/novncproxy_port': value => $port;
   }
 
-  include ::nova::vncproxy::common
-
   nova::generic_service { 'vncproxy':
     enabled        => $enabled,
     manage_service => $manage_service,


### PR DESCRIPTION
Partial-Bug: #1707985 - [Newton] novncproxy_base_url is not allowed to be set directly

The puppet code forces us to set vnc/novncproxy_base_url as the listen IP and port of vncproxy service
In HA case, the port and host are different from URL host and port

Change-Id: Id39b9487eab3e8d69bd49379d74ade8f592a4281