### PR TITLE
Vnc proxy common class removed from nova compute

### DIFF
--- a/nova/manifests/compute.pp
+++ b/nova/manifests/compute.pp
@@ -185,8 +185,6 @@ class nova::compute (
   }
 
   if ($vnc_enabled) {
-    include ::nova::vncproxy::common
-
     nova_config {
       'vnc/vncserver_proxyclient_address': value =>
         $vncserver_proxyclient_address;


### PR DESCRIPTION
Closes-Bug: #1707985 - vnc poxy base url should not be set by thirdparty in compute as well

This class call has been removed already from vncproxy.pp,
Needs to be removed for compute as well because R3.2 runs mitaka through puppet

This was not caught by CI because contrail-puppet repo runs only Kilo jobs in R3.2 branch

Change-Id: Ie3cd9625ca17fbaf12d347ec90a38f2553ed494c