### PR TITLE
fix keepalived version for newton puppet

### DIFF
--- a/keepalived/manifests/params.pp
+++ b/keepalived/manifests/params.pp
@@ -8,9 +8,9 @@ class keepalived::params {
 
   # for contrail HA, use correct keepalived version for centos
   if ($lsbdistrelease == "16.04") {
-      $pkg_ensure = '1.2.13-0~276~ubuntu14.04.1'
+      $pkg_ensure = '1:1.2.23~ubuntu16.04.1'
   } elsif ($lsbdistrelease == "14.04") {
-      $pkg_ensure = '1.2.13-0~276~ubuntu14.04.1'
+      $pkg_ensure = '1:1.2.23~ubuntu14.04.1'
   } elsif ($::operatingsystem == 'Centos' or $::operatingsystem == 'Fedora') {
       $pkg_ensure = 'present'
   } else {


### PR DESCRIPTION
CLoses-Bug: #1744144

keepalived version has been upgraded , puppet manifests needs to be get newer version of keepalived