### PR TITLE
fix keepalived version for mitaka

### DIFF
--- a/keepalived/manifests/params.pp
+++ b/keepalived/manifests/params.pp
@@ -8,7 +8,7 @@ class keepalived::params {
 
   # for contrail HA, use correct keepalived version for centos
   if ($lsbdistrelease == "14.04") {
-      $pkg_ensure = '1.2.13-0~276~ubuntu14.04.1'
+      $pkg_ensure = '1:1.2.23~ubuntu14.04.1'
   } elsif ($::operatingsystem == 'Centos' or $::operatingsystem == 'Fedora') {
       $pkg_ensure = 'present'
   } else {


### PR DESCRIPTION
Closes-Bug: #1744144

now newer packages is available in repo. so upgrade the keepalvied version on
puppet modules.